### PR TITLE
Make use of YAML role spec format; update download URL

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 if [ "up", "provision" ].include?(ARGV.first) &&
   !(File.directory?("roles/azavea.unzip") || File.symlink?("roles/azavea.unzip"))
 
-  unless system("ansible-galaxy install --force -r roles.txt -p roles")
+  unless system("ansible-galaxy install --force -r roles.yml -p roles")
     $stderr.puts "\nERROR: Please install Ansible 1.4.2+ so that the ansible-galaxy binary"
     $stderr.puts "is available."
     exit(1)

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,0 @@
-azavea.unzip,0.1.0

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,2 @@
+- src: azavea.unzip
+  version: 0.1.2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download Packer
-  get_url: url=https://dl.bintray.com/mitchellh/packer/packer_{{ packer_version }}_linux_amd64.zip
+  get_url: url=https://releases.hashicorp.com/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_amd64.zip
            dest=/usr/local/src/packer_{{ packer_version }}_linux_amd64.zip
 
 - name: Extract and install Packer


### PR DESCRIPTION
The is an attempt to silence deprecation warnings in Ansible 2.0. In addition to the YAML role specification format updates, I updated the Packer download URL so that it uses their CDN.

---

**Testing**

``` bash
$ cd examples
$ rm -rf roles/azavea.unzip
$ vagrant destroy -f && vagrant up
```
